### PR TITLE
Revert "build: Dex-preopt boot image by default on userdebug"

### DIFF
--- a/core/dex_preopt.mk
+++ b/core/dex_preopt.mk
@@ -25,19 +25,19 @@ SYSTEM_OTHER_ODEX_FILTER ?= app/% priv-app/%
 
 # The default values for pre-opting: always preopt PIC.
 # Conditional to building on linux, as dex2oat currently does not work on darwin.
-ifeq ($(HOST_OS),linux)
-  WITH_DEXPREOPT_PIC ?= true
-  WITH_DEXPREOPT ?= true
+#ifeq ($(HOST_OS),linux)
+#  WITH_DEXPREOPT_PIC ?= true
+#  WITH_DEXPREOPT ?= true
 # For an eng build only pre-opt the boot image. This gives reasonable performance and still
 # allows a simple workflow: building in frameworks/base and syncing.
-  ifneq (user,$(TARGET_BUILD_VARIANT))
-    WITH_DEXPREOPT_BOOT_IMG_ONLY ?= true
-  endif
+#  ifeq (eng,$(TARGET_BUILD_VARIANT))
+#    WITH_DEXPREOPT_BOOT_IMG_ONLY ?= true
+#  endif
 # Add mini-debug-info to the boot classpath unless explicitly asked not to.
-  ifneq (false,$(WITH_DEXPREOPT_DEBUG_INFO))
-    PRODUCT_DEX_PREOPT_BOOT_FLAGS += --generate-mini-debug-info
-  endif
-endif
+#  ifneq (false,$(WITH_DEXPREOPT_DEBUG_INFO))
+#    PRODUCT_DEX_PREOPT_BOOT_FLAGS += --generate-mini-debug-info
+#  endif
+#endif
 
 GLOBAL_DEXPREOPT_FLAGS :=
 ifeq ($(WITH_DEXPREOPT_PIC),true)


### PR DESCRIPTION
This reverts commit bd0529d628392dd29a071a561c1c56da9055904b.

Change-Id: I062a5523a59337abfa7a92512f8e014b4b238442

Revert "build: Dex-preopt boot image by default on userdebug"  …